### PR TITLE
Refactor: store outputs in `application/vnd.jupyterlab-imarkdown.*` MIME bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 [binder-badge]: https://mybinder.org/badge_logo.svg
 [binder]: https://mybinder.org/v2/gh/agoose77/jupyterlab-imarkdown.git/master?urlpath=lab
 
+
 A JupyterLab extension to embed rich output in Markdown cells, e.g.
 ```markdown
 The current value of x is {{ x }}
 ```
 
 ![preview](https://user-images.githubusercontent.com/1248413/133160417-95dfd03f-c0d5-43a3-8e1c-f3ae75949a8b.gif)
+
 
 ## Requirements
 

--- a/src/attachment.ts
+++ b/src/attachment.ts
@@ -1,0 +1,33 @@
+import { PartialJSONObject } from '@lumino/coreutils';
+
+export const OUTPUT_MIMETYPE = 'application/vnd.jupyterlab-imarkdown.output';
+export const ERROR_MIMETYPE = 'application/vnd.jupyterlab-imarkdown.error';
+
+export interface IBaseExpressionResult extends PartialJSONObject {
+  status: string;
+}
+
+export interface IExpressionOutput extends IBaseExpressionResult {
+  status: 'ok';
+  data: PartialJSONObject;
+  metadata: PartialJSONObject;
+}
+
+export interface IExpressionError extends IBaseExpressionResult {
+  status: 'error';
+  traceback: string[];
+  ename: string;
+  evalue: string;
+}
+
+export type IExpressionResult = IExpressionError | IExpressionOutput;
+
+export function isOutput(
+  output: IExpressionResult
+): output is IExpressionOutput {
+  return output.status === 'ok';
+}
+
+export function isError(output: IExpressionResult): output is IExpressionError {
+  return output.status === 'error';
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,10 @@
-import {
-  JupyterFrontEnd,
-  JupyterFrontEndPlugin
-} from '@jupyterlab/application';
-import { plugin } from './plugin';
-import {
-  INotebookTracker,
-  Notebook,
-  NotebookActions,
-  NotebookPanel,
-  StaticNotebook
-} from '@jupyterlab/notebook';
-import { IEditorServices } from '@jupyterlab/codeeditor';
-import { Cell, MarkdownCell } from '@jupyterlab/cells';
-import { JUPYTER_IMARKDOWN_EXPRESSION_PREFIX, XMarkdownCell } from './cell';
-import { loadUserExpressions } from './kernel';
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
+import { plugin } from "./plugin";
+import { INotebookTracker, Notebook, NotebookActions, NotebookPanel, StaticNotebook } from "@jupyterlab/notebook";
+import { IEditorServices } from "@jupyterlab/codeeditor";
+import { Cell, MarkdownCell } from "@jupyterlab/cells";
+import { ATTACHMENT_PREFIX, XMarkdownCell } from "./cell";
+import { loadUserExpressions } from "./kernel";
 
 class XMarkdownContentFactory extends NotebookPanel.ContentFactory {
   /**
@@ -57,7 +48,7 @@ function removeKernelAttachments(cell: XMarkdownCell) {
   const attachments = cell.model.attachments;
   attachments.keys
     .filter(key => {
-      key.startsWith(JUPYTER_IMARKDOWN_EXPRESSION_PREFIX);
+      key.startsWith(ATTACHMENT_PREFIX);
     })
     .map(attachments.remove);
 }
@@ -86,18 +77,19 @@ const executor: JupyterFrontEndPlugin<void> = {
           return;
         }
         // Load the user expressions for the given cell.
-        console.log(`Execution of ${cell.id} in ${ctx.session?.id}`);
         if (!isMarkdownCell(cell)) {
           return;
         }
-        console.log('Waiting for cell to render!');
+        console.log(
+          'Markdown cell was executed, waiting for render to complete ...'
+        );
 
         cell.doneRendering.then(() => {
-          // Clear existing cell attachments
+          console.log('Clearing results from cell attachments');
           removeKernelAttachments(cell);
-          console.log('Loading expressions from kernel');
+          console.log('Loading results from kernel');
           loadUserExpressions(cell, ctx).then(() => {
-            console.log('Re-rendering!');
+            console.log('Re-rendering cell!');
             cell.renderExpressions();
           });
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,19 @@
-import { JupyterFrontEnd, JupyterFrontEndPlugin } from "@jupyterlab/application";
-import { plugin } from "./plugin";
-import { INotebookTracker, Notebook, NotebookActions, NotebookPanel, StaticNotebook } from "@jupyterlab/notebook";
-import { IEditorServices } from "@jupyterlab/codeeditor";
-import { Cell, MarkdownCell } from "@jupyterlab/cells";
-import { ATTACHMENT_PREFIX, XMarkdownCell } from "./cell";
-import { loadUserExpressions } from "./kernel";
+import {
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from '@jupyterlab/application';
+import { plugin } from './plugin';
+import {
+  INotebookTracker,
+  Notebook,
+  NotebookActions,
+  NotebookPanel,
+  StaticNotebook
+} from '@jupyterlab/notebook';
+import { IEditorServices } from '@jupyterlab/codeeditor';
+import { Cell, MarkdownCell } from '@jupyterlab/cells';
+import { ATTACHMENT_PREFIX, XMarkdownCell } from './cell';
+import { loadUserExpressions } from './kernel';
 
 class XMarkdownContentFactory extends NotebookPanel.ContentFactory {
   /**

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -1,9 +1,14 @@
-import { XMarkdownCell } from "./cell";
-import { ISessionContext } from "@jupyterlab/apputils";
-import { IMarkdownCellModel } from "@jupyterlab/cells";
-import { KernelMessage } from "@jupyterlab/services";
-import { PartialJSONObject } from "@lumino/coreutils";
-import { ERROR_MIMETYPE, IExpressionResult, isError, OUTPUT_MIMETYPE } from "./attachment";
+import { XMarkdownCell } from './cell';
+import { ISessionContext } from '@jupyterlab/apputils';
+import { IMarkdownCellModel } from '@jupyterlab/cells';
+import { KernelMessage } from '@jupyterlab/services';
+import { PartialJSONObject } from '@lumino/coreutils';
+import {
+  ERROR_MIMETYPE,
+  IExpressionResult,
+  isError,
+  OUTPUT_MIMETYPE
+} from './attachment';
 
 /**
  * Load user expressions for given XMarkdown cell from kernel.

--- a/src/tokenize.ts
+++ b/src/tokenize.ts
@@ -1,6 +1,6 @@
 import MarkdownIt from 'markdown-it';
 
-export const JUPYTER_IMARKDOWN_EXPR_CLASS = 'im-expr';
+export const EXPR_CLASS = 'im-expr';
 
 // Skip char codes from given position
 function skipChars(state: any, pos: number, code: number): number {
@@ -62,7 +62,7 @@ function expressionPlugin(md: MarkdownIt): any {
 
     const exprToken = state.push('expr', 'input', 0);
     exprToken.attrSet('type', 'hidden');
-    exprToken.attrSet('class', JUPYTER_IMARKDOWN_EXPR_CLASS);
+    exprToken.attrSet('class', EXPR_CLASS);
     exprToken.attrSet('value', expression);
 
     return true;

--- a/style/base.css
+++ b/style/base.css
@@ -1,30 +1,30 @@
-.im-output-result {
+.im-result {
   display: inline;
 }
 
-.im-output-result.jp-RenderedText {
+.im-result.jp-RenderedText {
   padding-left: initial;
 }
 
-.im-output-result.jp-RenderedText > pre {
+.im-result.jp-RenderedText > pre {
   display: inline;
 }
 
-.im-output-result > .widget-inline-hbox,
-.im-output-result > .widget-inline-vbox {
+.im-result > .widget-inline-hbox,
+.im-result > .widget-inline-vbox {
   display: inline-flex;
 }
 
 /* style taken from ipywidgets/packages/base/css/index.css */
-.im-output-missing::before {
-  content: '\f127'; /* chain-broken */
+.im-error::before {
+  content: '\f127'; /* fa-chain-broken */
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;
   font-size: inherit;
   text-rendering: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  color: #d9534f;
+  color: var(--jp-warn-color0);
   padding: 3px;
   align-self: flex-start;
 }


### PR DESCRIPTION
This keeps the traceback information for other frontends to use/ignore, and let's us be smarter about "the kernel failed" vs "the notebook is missing metadata" cases.